### PR TITLE
Debuggin Shawn's bug

### DIFF
--- a/decider-backward-reasoning/main_test.go
+++ b/decider-backward-reasoning/main_test.go
@@ -8,6 +8,55 @@ import (
 	bbc "github.com/bbchallenge/bbchallenge-go"
 )
 
+func TestSkelet10(t *testing.T) {
+	// There is a debate whether or not Skelet's 10 machine is
+	// decidable by backward reasoning or not https://bbchallenge.org/3810716
+	// https://discuss.bbchallenge.org/t/skelet-10-backtracking/57
+	// Shawn is right, we have a bug..... This test should fail.
+	indices_to_test := []int{3810716}
+	DB, err := ioutil.ReadFile(DB_PATH)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i := range indices_to_test {
+		index := indices_to_test[i]
+		tm, err := bbc.GetMachineI(DB[:], index, true)
+		if err != nil {
+			t.Fail()
+		}
+		if deciderBackwardReasoning(tm, 300, true) {
+			fmt.Println(tm.ToAsciiTable(5))
+			fmt.Println(tm)
+
+			t.Fail()
+		}
+	}
+}
+
+func TestIndividualMachine(t *testing.T) {
+	// Machine used to expamplify the proof of https://github.com/bbchallenge/bbchallenge-proofs/blob/main/deciders/correctness-deciders.pdf
+	indices_to_test := []int{55897188}
+	DB, err := ioutil.ReadFile(DB_PATH)
+	if err != nil {
+		t.Fail()
+	}
+
+	for i := range indices_to_test {
+		index := indices_to_test[i]
+		tm, err := bbc.GetMachineI(DB[:], index, true)
+		if err != nil {
+			t.Fail()
+		}
+		if !deciderBackwardReasoning(tm, 2, true) {
+			fmt.Println(tm.ToAsciiTable(5))
+			fmt.Println(tm)
+
+			t.Fail()
+		}
+	}
+}
+
 func TestArgumentBackwardReasoning(t *testing.T) {
 	DB, err := ioutil.ReadFile(DB_PATH)
 	if err != nil {
@@ -17,7 +66,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 	t.Run(fmt.Sprintf("decider_not-backward-reasoning_bb5_winner"), func(t *testing.T) {
 		tm := bbc.GetBB5Winner()
 
-		if deciderBackwardReasoning(tm, 300) {
+		if deciderBackwardReasoning(tm, 300, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 			fmt.Println("Uh oh, expected false but got true")
@@ -26,7 +75,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 	})
 
 	// Below are indices
-	not_backward_reasoning_indices := []int{7410754}
+	not_backward_reasoning_indices := []int{7410754, 3810716}
 	for i := range not_backward_reasoning_indices {
 		index := not_backward_reasoning_indices[i]
 		t.Run(fmt.Sprintf("decider_not-backward-reasoning_%d", index), func(t *testing.T) {
@@ -34,7 +83,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if deciderBackwardReasoning(tm, 300) {
+			if deciderBackwardReasoning(tm, 300, false) {
 				fmt.Println(tm.ToAsciiTable(5))
 				fmt.Println(tm)
 				fmt.Println("Uh oh, expected false but got true: ", index)
@@ -53,7 +102,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if !deciderBackwardReasoning(tm, 300) {
+			if !deciderBackwardReasoning(tm, 300, false) {
 				fmt.Println("Uh oh, expected true but got false: ", index)
 				t.Fail()
 			}


### PR DESCRIPTION
For the discovery of the bug please refer to: https://discuss.bbchallenge.org/t/skelet-10-backtracking/57

I had overlooked the string-style tape management part of https://github.com/bbchallenge/bbchallenge-deciders/pull/5 in my review of that PR. Unfortunately, the tape management was buggued. I corrected the bug by reverting back to my style of tape management with maps, like done for Cyclers and Translated Cyclers.

I added more tests.