### PR TITLE
Debug backward reasoning bug found by lijil

### DIFF
--- a/decider-backward-reasoning/main.go
+++ b/decider-backward-reasoning/main.go
@@ -36,15 +36,16 @@ const MAX_MEMORY = 1000
 
 type TapeType map[int]byte
 
-type Configuration struct {
+type ConfigurationAndDepth struct {
 	Tape       TapeType
 	maxTapePos int
 	minTapePos int
 	State      byte
 	Head       int
+	Depth      int
 }
 
-func (c Configuration) tapeToString() string {
+func (c ConfigurationAndDepth) tapeToString() string {
 	tapeString := ""
 
 	// Assuming that Configurations are correctly
@@ -56,11 +57,11 @@ func (c Configuration) tapeToString() string {
 	return tapeString
 }
 
-func (c Configuration) toString() string {
+func (c ConfigurationAndDepth) toString() string {
 	return c.tapeToString() + string(c.State) + strconv.Itoa(c.Head)
 }
 
-func backwardTransition(config Configuration, write byte, read byte, direction byte, state byte) *Configuration {
+func backwardTransition(config ConfigurationAndDepth, write byte, read byte, direction byte, state byte) *ConfigurationAndDepth {
 
 	// Going in the reversed direction
 	reversedHeadMoveOffest := 1
@@ -88,14 +89,13 @@ func backwardTransition(config Configuration, write byte, read byte, direction b
 		newTape[pos] = value
 	}
 	newTape[previousHeadPosition] = read
-	previousConfiguration := Configuration{State: state, Tape: newTape, minTapePos: minHeadPos, maxTapePos: maxHeadPos, Head: previousHeadPosition}
+	previousConfiguration := ConfigurationAndDepth{State: state, Tape: newTape, minTapePos: minHeadPos, maxTapePos: maxHeadPos, Head: previousHeadPosition, Depth: config.Depth + 1}
 
 	return &previousConfiguration
 }
 
 func deciderBackwardReasoning(m bbc.TM, transitionTreeDepthLimit int, printRunInfo bool) bool {
-	var stack []Configuration
-	var depthStack []int
+	var stack []ConfigurationAndDepth
 
 	// map from state-1 to the mask of the ten Turing machine transitions that go to it
 	var predecessors [5][10]bool
@@ -107,24 +107,23 @@ func deciderBackwardReasoning(m bbc.TM, transitionTreeDepthLimit int, printRunIn
 		var initialTape TapeType = make(TapeType)
 		initialTape[0] = starting_bit
 		if my_new_state == 0 {
-			stack = append(stack, Configuration{Tape: initialTape, State: byte(i/2) + 1, Head: 0})
-			depthStack = append(depthStack, 0)
+			stack = append(stack, ConfigurationAndDepth{Tape: initialTape, State: byte(i/2) + 1, Head: 0, Depth: 0})
 			continue
 		}
 		predecessors[my_new_state-1][i] = true
 	}
 
-	var configuration Configuration
+	var configurationAndDepth ConfigurationAndDepth
 	var maxDepth int
 	seenConfigurations := map[string]bool{}
 	// continue until all configurations have contradicted or one branch is too long
 	for branches_searched := 0; len(stack) != 0; branches_searched += 1 {
 
-		configuration, stack = stack[len(stack)-1], stack[:len(stack)-1]
-		depth, depthStack := depthStack[len(depthStack)-1], depthStack[:len(depthStack)-1]
+		configurationAndDepth, stack = stack[len(stack)-1], stack[:len(stack)-1]
+		depth := configurationAndDepth.Depth
 
 		if printRunInfo {
-			fmt.Println("State:", configuration.State, ";", "Head:", configuration.Head, ";", "Tape:", configuration.tapeToString(), ";")
+			fmt.Println("State:", configurationAndDepth.State, ";", "Head:", configurationAndDepth.Head, ";", "Tape:", configurationAndDepth.tapeToString(), ";")
 		}
 
 		if depth > maxDepth {
@@ -136,13 +135,13 @@ func deciderBackwardReasoning(m bbc.TM, transitionTreeDepthLimit int, printRunIn
 			return false
 		}
 
-		if _, found := seenConfigurations[configuration.toString()]; found {
+		if _, found := seenConfigurations[configurationAndDepth.toString()]; found {
 			continue
 		}
 
-		seenConfigurations[configuration.toString()] = true
+		seenConfigurations[configurationAndDepth.toString()] = true
 
-		my_preds := predecessors[configuration.State-1]
+		my_preds := predecessors[configurationAndDepth.State-1]
 
 		for i := 0; i < 10; i += 1 {
 			if !my_preds[i] {
@@ -151,12 +150,11 @@ func deciderBackwardReasoning(m bbc.TM, transitionTreeDepthLimit int, printRunIn
 
 			transition := i * 3
 			read := i % 2
-			try_backwards := backwardTransition(configuration, m[transition], byte(read), m[transition+1], byte(i/2)+1)
+			try_backwards := backwardTransition(configurationAndDepth, m[transition], byte(read), m[transition+1], byte(i/2)+1)
 
 			// add the predecessor configuration to the stack if valid
 			if try_backwards != nil {
 				stack = append(stack, *try_backwards)
-				depthStack = append(depthStack, depth+1)
 			}
 		}
 	}

--- a/decider-backward-reasoning/main.go
+++ b/decider-backward-reasoning/main.go
@@ -95,9 +95,10 @@ func backwardTransition(config ConfigurationAndDepth, write byte, read byte, dir
 }
 
 var globalMaxDepth int
+var globalMaxDepthMachineId int
 var mutexMaxDepth sync.Mutex
 
-func deciderBackwardReasoning(m bbc.TM, transitionTreeDepthLimit int, printRunInfo bool, computeGlobalMaxDepth bool) bool {
+func deciderBackwardReasoning(m bbc.TM, machineId int, transitionTreeDepthLimit int, printRunInfo bool, computeGlobalMaxDepth bool) bool {
 	var stack []ConfigurationAndDepth
 
 	// map from state-1 to the mask of the ten Turing machine transitions that go to it
@@ -169,6 +170,7 @@ func deciderBackwardReasoning(m bbc.TM, transitionTreeDepthLimit int, printRunIn
 	if computeGlobalMaxDepth && len(stack) == 0 && maxDepth > globalMaxDepth {
 		mutexMaxDepth.Lock()
 		globalMaxDepth = maxDepth
+		globalMaxDepthMachineId = machineId
 		mutexMaxDepth.Unlock()
 	}
 
@@ -250,7 +252,7 @@ func main() {
 					if err != nil {
 						fmt.Println("Err:", err, n)
 					}
-					if deciderBackwardReasoning(m, transitionTreeDepth, false, reportMaxDepth) {
+					if deciderBackwardReasoning(m, n, transitionTreeDepth, false, reportMaxDepth) {
 						var arr [4]byte
 						binary.BigEndian.PutUint32(arr[0:4], uint32(n))
 						f.Write(arr[:])
@@ -271,7 +273,7 @@ func main() {
 					if err != nil {
 						fmt.Println("Err:", err, n)
 					}
-					if deciderBackwardReasoning(m, transitionTreeDepth, false, reportMaxDepth) {
+					if deciderBackwardReasoning(m, int(indexInDb), transitionTreeDepth, false, reportMaxDepth) {
 						var arr [4]byte
 						binary.BigEndian.PutUint32(arr[0:4], indexInDb)
 						f.Write(arr[:])
@@ -288,5 +290,6 @@ func main() {
 
 	if reportMaxDepth {
 		fmt.Println("Max depth:", globalMaxDepth)
+		fmt.Println("Reach by machine with id:", globalMaxDepthMachineId)
 	}
 }

--- a/decider-backward-reasoning/main_test.go
+++ b/decider-backward-reasoning/main_test.go
@@ -66,7 +66,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 	t.Run(fmt.Sprintf("decider_not-backward-reasoning_bb5_winner"), func(t *testing.T) {
 		tm := bbc.GetBB5Winner()
 
-		if deciderBackwardReasoning(tm, 300, false) {
+		if deciderBackwardReasoning(tm, 50, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 			fmt.Println("Uh oh, expected false but got true")
@@ -83,7 +83,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if deciderBackwardReasoning(tm, 300, false) {
+			if deciderBackwardReasoning(tm, 50, false) {
 				fmt.Println(tm.ToAsciiTable(5))
 				fmt.Println(tm)
 				fmt.Println("Uh oh, expected false but got true: ", index)
@@ -102,7 +102,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if !deciderBackwardReasoning(tm, 300, false) {
+			if !deciderBackwardReasoning(tm, 50, false) {
 				fmt.Println("Uh oh, expected true but got false: ", index)
 				t.Fail()
 			}

--- a/decider-backward-reasoning/main_test.go
+++ b/decider-backward-reasoning/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"testing"
 
 	bbc "github.com/bbchallenge/bbchallenge-go"
@@ -25,7 +26,7 @@ func TestSkelet10(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		if deciderBackwardReasoning(tm, 300, true, false) {
+		if deciderBackwardReasoning(tm, i, 300, true, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 
@@ -48,7 +49,7 @@ func TestIndividualMachine(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		if !deciderBackwardReasoning(tm, 2, true, false) {
+		if !deciderBackwardReasoning(tm, index, 2, true, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 
@@ -66,7 +67,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 	t.Run(fmt.Sprintf("decider_not-backward-reasoning_bb5_winner"), func(t *testing.T) {
 		tm := bbc.GetBB5Winner()
 
-		if deciderBackwardReasoning(tm, 50, false, false) {
+		if deciderBackwardReasoning(tm, math.MaxInt32, 50, false, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 			fmt.Println("Uh oh, expected false but got true")
@@ -83,7 +84,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if deciderBackwardReasoning(tm, 50, false, false) {
+			if deciderBackwardReasoning(tm, index, 50, false, false) {
 				fmt.Println(tm.ToAsciiTable(5))
 				fmt.Println(tm)
 				fmt.Println("Uh oh, expected false but got true: ", index)
@@ -102,7 +103,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if !deciderBackwardReasoning(tm, 50, false, false) {
+			if !deciderBackwardReasoning(tm, index, 50, false, false) {
 				fmt.Println("Uh oh, expected true but got false: ", index)
 				t.Fail()
 			}

--- a/decider-backward-reasoning/main_test.go
+++ b/decider-backward-reasoning/main_test.go
@@ -25,7 +25,7 @@ func TestSkelet10(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		if deciderBackwardReasoning(tm, 300, true) {
+		if deciderBackwardReasoning(tm, 300, true, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 
@@ -48,7 +48,7 @@ func TestIndividualMachine(t *testing.T) {
 		if err != nil {
 			t.Fail()
 		}
-		if !deciderBackwardReasoning(tm, 2, true) {
+		if !deciderBackwardReasoning(tm, 2, true, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 
@@ -66,7 +66,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 	t.Run(fmt.Sprintf("decider_not-backward-reasoning_bb5_winner"), func(t *testing.T) {
 		tm := bbc.GetBB5Winner()
 
-		if deciderBackwardReasoning(tm, 50, false) {
+		if deciderBackwardReasoning(tm, 50, false, false) {
 			fmt.Println(tm.ToAsciiTable(5))
 			fmt.Println(tm)
 			fmt.Println("Uh oh, expected false but got true")
@@ -83,7 +83,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if deciderBackwardReasoning(tm, 50, false) {
+			if deciderBackwardReasoning(tm, 50, false, false) {
 				fmt.Println(tm.ToAsciiTable(5))
 				fmt.Println(tm)
 				fmt.Println("Uh oh, expected false but got true: ", index)
@@ -102,7 +102,7 @@ func TestArgumentBackwardReasoning(t *testing.T) {
 			if err != nil {
 				t.Fail()
 			}
-			if !deciderBackwardReasoning(tm, 50, false) {
+			if !deciderBackwardReasoning(tm, 50, false, false) {
 				fmt.Println("Uh oh, expected true but got false: ", index)
 				t.Fail()
 			}

--- a/index-utilities/main.go
+++ b/index-utilities/main.go
@@ -6,19 +6,41 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"sort"
 )
+
+type TypeIndices []uint32
+
+func (f TypeIndices) Len() int {
+	return len(f)
+}
+
+func (f TypeIndices) Less(i, j int) bool {
+	return f[i] < f[j]
+}
+
+func (f TypeIndices) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
 
 func main() {
 
-	argBelong := flag.Bool("b", true, "test if machine belongs to index")
+	argBelong := flag.Bool("b", false, "test if machine belongs to index")
 	argIndexFileName := flag.String("f", "", "index of machines indices")
 	argMachineIndex := flag.Int("m", 0, "machine index to test")
+	argTestSorted := flag.Bool("ts", false, "test if machine index file is sorted")
+	argSortFile := flag.Bool("s", false, "outputs sorted version of file")
+	argTestSameContent := flag.String("sc", "", "tests that two files have same content modulo order")
 
 	flag.Parse()
 
 	belong := *argBelong
 	indexFileName := *argIndexFileName
 	machineIndex := *argMachineIndex
+	testSorted := *argTestSorted
+	sortFile := *argSortFile
+	otherIndexFileName := *argTestSameContent
 
 	var err error
 	var index []byte
@@ -30,6 +52,11 @@ func main() {
 		}
 	}
 
+	var machineIndices TypeIndices
+	for i := 0; i < len(index); i += 4 {
+		machineIndices = append(machineIndices, binary.BigEndian.Uint32(index[i:i+4]))
+	}
+
 	if belong {
 		for i := 0; i < len(index); i += 4 {
 			if machineIndex == int(binary.BigEndian.Uint32(index[i:i+4])) {
@@ -39,6 +66,67 @@ func main() {
 		}
 		fmt.Println("Machine", machineIndex, "does not belongs to", indexFileName)
 		os.Exit(-1)
+	}
+
+	if testSorted {
+		for i := 1; i < len(machineIndices); i += 1 {
+			if machineIndices[i] < machineIndices[i-1] {
+				fmt.Println("FAILED: index is not sorted!")
+				os.Exit(-1)
+			}
+		}
+		fmt.Println("SUCCESS: index is sorted")
+		os.Exit(0)
+	}
+
+	if sortFile {
+		sort.Sort(machineIndices)
+		fmt.Println("output/" + filepath.Base(indexFileName))
+		f, _ := os.OpenFile("output/"+filepath.Base(indexFileName),
+			os.O_CREATE|os.O_WRONLY, 0644)
+		for i := 0; i < len(machineIndices); i += 1 {
+			var arr [4]byte
+			binary.BigEndian.PutUint32(arr[0:4], machineIndices[i])
+			f.Write(arr[:])
+		}
+		f.Close()
+	}
+
+	if otherIndexFileName != "" {
+
+		var other_index []byte
+
+		other_index, err = ioutil.ReadFile(otherIndexFileName)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
+
+		var otherMachineIndices TypeIndices
+		for i := 0; i < len(other_index); i += 4 {
+			otherMachineIndices = append(otherMachineIndices, binary.BigEndian.Uint32(other_index[i:i+4]))
+		}
+
+		if len(machineIndices) != len(otherMachineIndices) {
+			fmt.Println("FAILED: different sizes!")
+			os.Exit(-1)
+		}
+
+		var seen map[uint32]bool = make(map[uint32]bool)
+		for i := 0; i < len(machineIndices); i += 1 {
+			seen[machineIndices[i]] = true
+		}
+
+		for i := 0; i < len(otherMachineIndices); i += 1 {
+			if ok, _ := seen[otherMachineIndices[i]]; !ok {
+				fmt.Println("FAILED: content differs!")
+				os.Exit(-1)
+			}
+		}
+
+		fmt.Println("SUCCESS: same content!")
+		os.Exit(0)
+
 	}
 
 }


### PR DESCRIPTION
There was a bug on the depth stack due to misuse of go's operator `:=` with slices.

To correct this bug, I merged the depth stack with the configuration stack to simplify the code.

Note that now running to depth 300 is not feasible anymore (too long). @sligocki and @lijil reported max depth of 29, hence we'll run with 50.